### PR TITLE
Remove </div> without pair

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,3 @@
-  </div>
   {{ template "_internal/google_analytics_async.html" . }}
 </body>
 </html>


### PR DESCRIPTION
Found an extra `</div>`, it doesn't have pair.