### PR TITLE
fix justification of nav links and improve performance

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -15,10 +15,10 @@
 
   <div id=links>
     {{ if .PrevInSection }}
-      <a class="basic-alignment left" href="{{.PrevInSection.Permalink}}">&laquo; {{.PrevInSection.Title}}</a>
+      <a class="left-justify" href="{{.PrevInSection.Permalink}}">&laquo; {{.PrevInSection.Title}}</a>
     {{ end }}
     {{ if .NextInSection }}
-      <a class="basic-alignment left" href="{{.NextInSection.Permalink}}">{{.NextInSection.Title}} &raquo;</a>
+      <a class="right-justify" href="{{.NextInSection.Permalink}}">{{.NextInSection.Title}} &raquo;</a>
     {{ end }}
   </div>
 </section>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,10 +6,10 @@
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="referrer" content="no-referrer">
-    {{ if .Site.Params.description }}<meta name="description" content="{{ .Site.Params.description }}">{{ end }}
+    <meta name="description" content="{{ .Description | default .Site.Params.Description }}">
 
     {{ if not .Site.Params.disableWebFonts }}
-      <link href='https://fonts.googleapis.com/css?family=Open+Sans:400|Old+Standard+TT:400&display=swap' rel='stylesheet' type='text/css'>
+      <link href="https://fonts.googleapis.com/css?family=Open+Sans:400|Old+Standard+TT:400&display=swap" rel="stylesheet" media="print" type="text/css" onload="this.media='all'">
     {{ end }}
 
     <title>

--- a/layouts/partials/styles.html
+++ b/layouts/partials/styles.html
@@ -35,10 +35,12 @@
 
   .left-justify {
     float: left;
+    width: 45%;
   }
 
   .right-justify {
     float:right;
+    width: 45%;
   }
 
   pre, code {


### PR DESCRIPTION
The `layouts/_default/single.html` page has links at the bottom to navigate to/from additional posts. These `<a>` elements were given a class that was not specified with any styling in the `styles.html` file. As a result, the links would stack on top of each other in a left-justified manner like so:

<img width="479" alt="Screen Shot 2020-05-17 at 6 51 35 PM" src="https://user-images.githubusercontent.com/16453494/82168580-e3e02500-9873-11ea-836f-56cc3a9c38e7.png">

I modified the page to use an existing justification attribute for each link, and I added constraints for those attributes (via the `width` property) so that the links will display side-by-side. Here's a screenshot of the result:

<img width="432" alt="Screen Shot 2020-05-17 at 6 52 04 PM" src="https://user-images.githubusercontent.com/16453494/82168648-1427c380-9874-11ea-89c6-ccabffce3a36.png">
