### PR TITLE
allow setting configurable CSS/SCSS overrides

### DIFF
--- a/layouts/partials/styles.html
+++ b/layouts/partials/styles.html
@@ -116,24 +116,16 @@
 
   blockquote {
     font-family:"Old Standard TT",serif;
-    text-align:center;
-    padding:50px;
+    text-align:left;
+    padding-left:50px;
+    padding-right:50px;
+    padding-bottom: 0px;
+    padding-top: 0px;
   }
 
   blockquote p {
     display:inline-block;
     font-style:italic;
-  }
-
-  blockquote:before,blockquote:after {
-    font-family:"Old Standard TT",serif;
-    content:'\201C';
-    font-size:35px;
-    color:#403c3b;
-  }
-
-  blockquote:after {
-    content:'\201D';
   }
 
   hr {

--- a/layouts/partials/styles.html
+++ b/layouts/partials/styles.html
@@ -115,17 +115,11 @@
   }
 
   blockquote {
-    font-family:"Old Standard TT",serif;
     text-align:left;
     padding-left:50px;
     padding-right:50px;
     padding-bottom: 0px;
     padding-top: 0px;
-  }
-
-  blockquote p {
-    display:inline-block;
-    font-style:italic;
   }
 
   hr {

--- a/layouts/partials/styles.html
+++ b/layouts/partials/styles.html
@@ -380,3 +380,8 @@
     }
   }
 </style>
+{{ $optionsCss := (dict "outputStyle" "compressed") }}
+{{ range .Site.Params.customCss -}}
+{{ $customStyle := resources.Get . | toCSS $optionsCss | fingerprint }}
+<link rel="stylesheet" href="{{ $customStyle.RelPermalink }}" integrity="{{ $customStyle.Data.Integrity }}">
+{{- end }}


### PR DESCRIPTION
This was a quick hack I did according to [this blog post](https://mattmayes.com/posts/2019/hugo-add-custom-css-properly/) to add support for specifying custom CSS in the site itself. 

I think that the `toCSS` pipeline might rely on hugo-extended, in which case I understand if you don't want to accept this change. I'm just really liking the theme so I wanted to offer this in case you find it useful.

Thanks!