### PR TITLE
Fix breaking footer.html by updating the google_analytics template

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,3 @@
-  {{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 </body>
 </html>


### PR DESCRIPTION
This repository fails with newer versions of hugo because of this :
https://discourse.gohugo.io/t/build-error-on-v0-125-2-calling-internal-template-internal-google-analytics-async-html/49410

This PR fixes this by updating `footer.html` 